### PR TITLE
Wrap `h` in `hyperscript-attribute-to-property` to allow `class`

### DIFF
--- a/h.js
+++ b/h.js
@@ -1,1 +1,4 @@
-module.exports = require('virtual-dom/h');
+var attrToProp = require('hyperscript-attribute-to-property');
+var h = require('virtual-dom/h');
+
+module.exports = attrToProp(h);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dom-delegator": "13.1.0",
     "dover": "1.2.0",
     "global": "4.3.0",
+    "hyperscript-attribute-to-property": "^1.0.0",
     "main-loop": "3.2.0",
     "main-loop-app": "0.1.0",
     "observ": "0.2.0",


### PR DESCRIPTION
Allows people to write `class`, `for`, and a couple of others.

``` js
h('div', {class: 'foo'}, 'class, not className!')
```

[hyperx uses it](https://github.com/substack/hyperx/blob/master/index.js#L10).
